### PR TITLE
Simplify site to redirect to reipur.dk

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-mixedenergy.vezit.net

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,0 @@
-theme: mixedenergy
-title: Mixedenergis's homepage
-description: Mixedenergis's homepage

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Hello World from docs</title>
-</head>
-<body>
-    <h1>Hello, World! docs</h1>
-</body>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,29 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Hello, World!</title>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="5; url=https://reipur.dk">
+    <title>Redirecting...</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding-top: 50px; }
+    </style>
+    <script>
+      var seconds = 5;
+      function countdown() {
+        if (seconds > 0) {
+          document.getElementById('countdown').textContent = seconds;
+          seconds--;
+          setTimeout(countdown, 1000);
+        } else {
+          window.location.href = 'https://reipur.dk';
+        }
+      }
+      window.onload = countdown;
+    </script>
 </head>
 <body>
-    <h1>Hello, World!</h1>
-    <p>Welcome to my website.</p>
-    <p>My name is <strong>John Doe</strong>.</p>
-
+    <h1>You are being redirected to <a href="https://reipur.dk">reipur.dk</a>, the creator of this domain.</h1>
+    <p>Redirecting in <span id="countdown">5</span> seconds...</p>
+    <p>If you are not redirected automatically, click <a href="https://reipur.dk">here</a>.</p>
 </body>
 </html>

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,0 @@
-hello world


### PR DESCRIPTION
## Summary
- clean up repository, leaving only a single start page
- add start page that redirects to reipur.dk after 5 seconds with a manual link

## Testing
- `npm test` *(fails: no package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842a4da8ed8832c9c3d7c0c6ba1537d